### PR TITLE
cambios textos y estructura H1 - H2

### DIFF
--- a/landing/components/psicologos/ProfileDesktop.vue
+++ b/landing/components/psicologos/ProfileDesktop.vue
@@ -23,13 +23,18 @@
 						</v-col>
 						<v-col cols="8">
 							<div>
-								<div
+								<h1 v-if="psychologist.gender == 'male'"
 									class="text-left font-weight-bold"
-									style="color: #3c3c3b; font-size: 28px"
-								>
-									{{ psychologist.name }}
+									style="color: #3c3c3b; font-size: 28px">
+									Psicólogo {{ psychologist.name }}
 									{{ psychologist.lastName && psychologist.lastName }}
-								</div>
+								</h1>
+								<h1 v-else
+									class="text-left font-weight-bold"
+									style="color: #3c3c3b; font-size: 28px">
+									Psicóloga {{ psychologist.name }}
+								{{ psychologist.lastName && psychologist.lastName }}
+								</h1>
 							</div>
 							<div
 								class="text-left font-weight-medium pa-2"
@@ -94,7 +99,7 @@
 					<v-divider class="mx-4"></v-divider>
 					<v-card-text>
 						<div class="mb-4 text-left subtitle-1 primary--text">Experiencia</div>
-						<div class="body-1 text-left">
+						<h2 class="body-1 text-left">
 							<ul v-if="psychologist.experience && psychologist.experience.length">
 								<li
 									v-for="(experience, i) in psychologist.experience"
@@ -107,7 +112,7 @@
 									>
 								</li>
 							</ul>
-						</div>
+						</h2>
 					</v-card-text>
 					<v-divider class="mx-4"></v-divider>
 					<v-card-text>

--- a/landing/pages/_slug.vue
+++ b/landing/pages/_slug.vue
@@ -69,9 +69,7 @@ export default {
 	},
 	head() {
 		return {
-			title: `${
-				this.psychologist ? this.psychologist.name + ' ' + this.psychologist.lastName : ''
-			} | Hablaquí`,
+			title: `${this.psychologist ? 'Psicólogo '+ this.psychologist.name + ' ' + this.psychologist.lastName + ' $'+ this.psychologist.sessionPrices.video :''}`,
 			meta: [
 				{
 					hid: 'description',

--- a/landing/pages/auth.vue
+++ b/landing/pages/auth.vue
@@ -236,7 +236,7 @@ export default {
 		return {
 			meta: [
 				{
-					hid:"seo:robots",
+					hid:"robots",
 					name:"robots",
 					content:"noindex",
 				},

--- a/landing/pages/psicologos/_slug.vue
+++ b/landing/pages/psicologos/_slug.vue
@@ -28,7 +28,7 @@ export default {
 	},
 	head() {
 		return {
-			title: `Psicólogos en ${this.$route.params.slug} | Hablaquí`,
+			title: `Psicólogos en ${this.$route.params.slug} | Desde $15.500`,
 			meta: [
 				{
 					hid: 'description',


### PR DESCRIPTION
En perfil psicologos (antes solo habian divs), agegué H's, y mejoras en meta etiquetas. Esto va a ayudar a mejorar posicion organica de los perfiles y el CTR.